### PR TITLE
Fix bug where projectiles pass through launch pads

### DIFF
--- a/Assets/Prefabs/Skull Arena Prefabs/force pad.prefab
+++ b/Assets/Prefabs/Skull Arena Prefabs/force pad.prefab
@@ -593,7 +593,7 @@ GameObject:
   - component: {fileID: 4224148286998523964}
   - component: {fileID: 2070327977738986292}
   - component: {fileID: 2070327977738986295}
-  m_Layer: 0
+  m_Layer: 12
   m_Name: force pad
   m_TagString: Untagged
   m_Icon: {fileID: 0}

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -22,7 +22,7 @@ TagManager:
   - Portal
   - FirstPersonWeapon
   - Interactable
-  - 
+  - IgnoreProjectiles
   - 
   - 
   - 


### PR DESCRIPTION
Created the IgnoreProjectiles layer and assigned it to Launch Pad. 